### PR TITLE
cd: fix license to MIT

### DIFF
--- a/clients/netcore/apiclient.csproj
+++ b/clients/netcore/apiclient.csproj
@@ -22,7 +22,7 @@
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-    <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Seems like nuget.org has integrated a license check, the previously set License is invalid and fails the pipeline: https://github.com/tributech-solutions/tributech-dsk-api-clients/actions/runs/343096202

Adjusted to the correct short identifier for the MIT license: https://opensource.org/licenses/MIT