### PR TITLE
feat: ProofLocation Validation Result Entity (DSK-2228)

### DIFF
--- a/clients/netcore/DataAPIClient.gen.cs
+++ b/clients/netcore/DataAPIClient.gen.cs
@@ -111,21 +111,23 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> SaveProofLocationAsync(CreateProofLocationModel body, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
-        /// Update single ProofLocation
+        /// Update single ProofLocation 
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">Single ProofLocation to be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body);
+        System.Threading.Tasks.Task UpdateProofLocationAsync(UpdateProofLocationModel body);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update single ProofLocation
+        /// Update single ProofLocation 
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">Single ProofLocation to be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Add multiple ProofLocations.
@@ -146,20 +148,22 @@ namespace Tributech.Dsk.Api.Clients.DataApi
 
         /// <summary>
         /// Update multiple ProofLocations
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body);
+        System.Threading.Tasks.Task UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
         /// Update multiple ProofLocations
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Query basic statistics of a value metadata id
@@ -1242,24 +1246,26 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         }
 
         /// <summary>
-        /// Update single ProofLocation
+        /// Update single ProofLocation 
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">Single ProofLocation to be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body)
+        public virtual System.Threading.Tasks.Task UpdateProofLocationAsync(UpdateProofLocationModel body)
         {
             return UpdateProofLocationAsync(body, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update single ProofLocation
+        /// Update single ProofLocation 
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">Single ProofLocation to be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/prooflocation");
@@ -1274,7 +1280,6 @@ namespace Tributech.Dsk.Api.Clients.DataApi
                     content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json-patch+json");
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("PUT");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -1299,12 +1304,7 @@ namespace Tributech.Dsk.Api.Clients.DataApi
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<UInt64ReadCreateResponseModel>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
+                            return;
                         }
                         else
                         if (status_ == 400)
@@ -1459,11 +1459,12 @@ namespace Tributech.Dsk.Api.Clients.DataApi
 
         /// <summary>
         /// Update multiple ProofLocations
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body)
+        public virtual System.Threading.Tasks.Task UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body)
         {
             return UpdateProofLocationsAsync(body, System.Threading.CancellationToken.None);
         }
@@ -1471,11 +1472,12 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
         /// Update multiple ProofLocations
+        /// <br/>!! BEWARE !! Only Proof Location(s) from the current Node are supported
         /// </summary>
         /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/prooflocations");
@@ -1490,7 +1492,6 @@ namespace Tributech.Dsk.Api.Clients.DataApi
                     content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json-patch+json");
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("PUT");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -1515,12 +1516,7 @@ namespace Tributech.Dsk.Api.Clients.DataApi
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<UInt64ReadCreateResponseModel>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
+                            return;
                         }
                         else
                         if (status_ == 400)
@@ -4573,11 +4569,14 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Uri { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public ValidateProofResultEnumeration ValidationResult { get; set; }
+
         /// <summary>
-        /// Result of the latest Validation (optional)
+        /// Execution Time stamp of the Validation (optional)
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? ValidationResult { get; set; }
+        [Newtonsoft.Json.JsonProperty("validationTimestamp", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTimeOffset? ValidationTimestamp { get; set; }
 
     }
 
@@ -4815,11 +4814,8 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         [Newtonsoft.Json.JsonProperty("size", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long Size { get; set; }
 
-        /// <summary>
-        /// Result of the latest Validation (optional)
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? ValidationResult { get; set; }
+        [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public ValidateProofResultEnumeration ValidationResult { get; set; }
 
         /// <summary>
         /// Timestamp of the latest Validation (optional)
@@ -5259,11 +5255,8 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Uri { get; set; }
 
-        /// <summary>
-        /// Result of the latest Validation
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.Always)]
-        public int ValidationResult { get; set; }
+        public ValidateProofResultEnumeration ValidationResult { get; set; }
 
         /// <summary>
         /// Timestamp of the latest Validation
@@ -5271,6 +5264,30 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         [Newtonsoft.Json.JsonProperty("validationTimestamp", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public System.DateTimeOffset ValidationTimestamp { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum ValidateProofResultEnumeration
+    {
+
+        _0 = 0,
+
+        _1 = 1,
+
+        _2 = 2,
+
+        _3 = 3,
+
+        _4 = 4,
+
+        _5 = 5,
+
+        _6 = 6,
+
+        _7 = 7,
+
+        _99 = 99,
 
     }
 

--- a/clients/netcore/DataAPIClient.gen.cs
+++ b/clients/netcore/DataAPIClient.gen.cs
@@ -42,6 +42,21 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationAsync(System.Guid valueMetadataId, System.DateTimeOffset nextLastTimestamp, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
+        /// Get ProofLocation of a data stream for a given point in time.
+        /// </summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get ProofLocation of a data stream for a given point in time.
+        /// </summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
         /// Get pageable ProofLocations by ValueMetadataId for a certain time range.
         /// </summary>
         /// <param name="valueMetadataId">The ValueMedataId of the data stream</param>
@@ -94,6 +109,23 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> SaveProofLocationAsync(CreateProofLocationModel body, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
         /// Add multiple ProofLocations.
         /// </summary>
         /// <param name="body">The list of ProofLocations to be created.</param>
@@ -109,6 +141,23 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         /// <returns>ProofLocations created successfully. Returns the number of saved ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> SaveProofLocationsAsync(System.Collections.Generic.IEnumerable<CreateProofLocationModel> body, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Query basic statistics of a value metadata id
@@ -837,6 +886,106 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         }
 
         /// <summary>
+        /// Get ProofLocation of a data stream for a given point in time.
+        /// </summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri)
+        {
+            return GetProofLocationViaUriAsync(uri, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get ProofLocation of a data stream for a given point in time.
+        /// </summary>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri, System.Threading.CancellationToken cancellationToken)
+        {
+            if (uri == null)
+                throw new System.ArgumentNullException("uri");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/prooflocation/{uri}");
+            urlBuilder_.Replace("{uri}", System.Uri.EscapeDataString(ConvertToString(uri, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ReadProofLocationModel>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ProblemDetails>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("Server Error", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Get pageable ProofLocations by ValueMetadataId for a certain time range.
         /// </summary>
         /// <param name="valueMetadataId">The ValueMedataId of the data stream</param>
@@ -1089,6 +1238,111 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         }
 
         /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body)
+        {
+            return UpdateProofLocationAsync(body, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/prooflocation");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(body, _settings.Value));
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json-patch+json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<UInt64ReadCreateResponseModel>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ValidationProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ValidationProblemDetails>("Invalid request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ReadErrorResponseModel>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ReadErrorResponseModel>("Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Add multiple ProofLocations.
         /// </summary>
         /// <param name="body">The list of ProofLocations to be created.</param>
@@ -1178,6 +1432,111 @@ namespace Tributech.Dsk.Api.Clients.DataApi
                         {
                             string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("Duplicate timestamp value violates unique constraint.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body)
+        {
+            return UpdateProofLocationsAsync(body, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update mulitple ProofLocations
+        /// </summary>
+        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/prooflocations");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(body, _settings.Value));
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json-patch+json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<UInt64ReadCreateResponseModel>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ValidationProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ValidationProblemDetails>("Invalid request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ReadErrorResponseModel>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ReadErrorResponseModel>("Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -4210,6 +4569,12 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Uri { get; set; }
 
+        /// <summary>
+        /// Result of the latest Validation (optional)
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? ValidationResult { get; set; }
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -4445,6 +4810,18 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         /// </summary>
         [Newtonsoft.Json.JsonProperty("size", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long Size { get; set; }
+
+        /// <summary>
+        /// Result of the latest Validation (optional)
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? ValidationResult { get; set; }
+
+        /// <summary>
+        /// Timestamp of the latest Validation (optional)
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("validationTimestamp", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTimeOffset? ValidationTimestamp { get; set; }
 
     }
 
@@ -4865,6 +5242,31 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         /// </summary>
         [Newtonsoft.Json.JsonProperty("insertedCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long InsertedCount { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateProofLocationModel
+    {
+        /// <summary>
+        /// Uri to retrieve the ProofLocation from the Trust API.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("uri", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Uri { get; set; }
+
+        /// <summary>
+        /// Result of the latest Validation
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.Always)]
+        public int ValidationResult { get; set; }
+
+        /// <summary>
+        /// Timestamp of the latest Validation
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("validationTimestamp", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.DateTimeOffset ValidationTimestamp { get; set; }
 
     }
 

--- a/clients/netcore/DataAPIClient.gen.cs
+++ b/clients/netcore/DataAPIClient.gen.cs
@@ -42,16 +42,18 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationAsync(System.Guid valueMetadataId, System.DateTimeOffset nextLastTimestamp, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
-        /// Get ProofLocation of a data stream for a given point in time.
+        /// Get ProofLocation of a data stream for a specified URI.
         /// </summary>
+        /// <param name="uri">Uri to retrieve the ProofLocation from the Trust API.</param>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get ProofLocation of a data stream for a given point in time.
+        /// Get ProofLocation of a data stream for a specified URI.
         /// </summary>
+        /// <param name="uri">Uri to retrieve the ProofLocation from the Trust API.</param>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri, System.Threading.CancellationToken cancellationToken);
@@ -109,19 +111,19 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> SaveProofLocationAsync(CreateProofLocationModel body, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update single ProofLocation
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
-        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <param name="body">Single ProofLocation to be updated</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update single ProofLocation
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
-        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <param name="body">Single ProofLocation to be updated</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken);
 
@@ -143,18 +145,18 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> SaveProofLocationsAsync(System.Collections.Generic.IEnumerable<CreateProofLocationModel> body, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update multiple ProofLocations
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update multiple ProofLocations
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken);
@@ -886,8 +888,9 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         }
 
         /// <summary>
-        /// Get ProofLocation of a data stream for a given point in time.
+        /// Get ProofLocation of a data stream for a specified URI.
         /// </summary>
+        /// <param name="uri">Uri to retrieve the ProofLocation from the Trust API.</param>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri)
@@ -897,8 +900,9 @@ namespace Tributech.Dsk.Api.Clients.DataApi
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get ProofLocation of a data stream for a given point in time.
+        /// Get ProofLocation of a data stream for a specified URI.
         /// </summary>
+        /// <param name="uri">Uri to retrieve the ProofLocation from the Trust API.</param>
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<ReadProofLocationModel> GetProofLocationViaUriAsync(string uri, System.Threading.CancellationToken cancellationToken)
@@ -1238,10 +1242,10 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         }
 
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update single ProofLocation
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
-        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <param name="body">Single ProofLocation to be updated</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body)
         {
@@ -1250,10 +1254,10 @@ namespace Tributech.Dsk.Api.Clients.DataApi
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update single ProofLocation
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
-        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
+        /// <param name="body">Single ProofLocation to be updated</param>
+        /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocation.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationAsync(UpdateProofLocationModel body, System.Threading.CancellationToken cancellationToken)
         {
@@ -1454,9 +1458,9 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         }
 
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update multiple ProofLocations
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body)
@@ -1466,9 +1470,9 @@ namespace Tributech.Dsk.Api.Clients.DataApi
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update mulitple ProofLocations
+        /// Update multiple ProofLocations
         /// </summary>
-        /// <param name="body">The list of ProofLocations to be created</param>
+        /// <param name="body">The list of ProofLocations which shall be updated</param>
         /// <returns>ProofLocations updated successfully. Returns the number of updated ProofsLocations.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<UInt64ReadCreateResponseModel> UpdateProofLocationsAsync(System.Collections.Generic.IEnumerable<UpdateProofLocationModel> body, System.Threading.CancellationToken cancellationToken)

--- a/clients/netcore/DataAPIClient.gen.cs
+++ b/clients/netcore/DataAPIClient.gen.cs
@@ -4570,6 +4570,7 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         public string Uri { get; set; }
 
         [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ValidateProofResultEnumeration ValidationResult { get; set; }
 
         /// <summary>
@@ -4815,6 +4816,7 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         public long Size { get; set; }
 
         [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ValidateProofResultEnumeration ValidationResult { get; set; }
 
         /// <summary>
@@ -5256,6 +5258,8 @@ namespace Tributech.Dsk.Api.Clients.DataApi
         public string Uri { get; set; }
 
         [Newtonsoft.Json.JsonProperty("validationResult", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ValidateProofResultEnumeration ValidationResult { get; set; }
 
         /// <summary>
@@ -5271,23 +5275,32 @@ namespace Tributech.Dsk.Api.Clients.DataApi
     public enum ValidateProofResultEnumeration
     {
 
-        _0 = 0,
+        [System.Runtime.Serialization.EnumMember(Value = @"Success")]
+        Success = 0,
 
-        _1 = 1,
+        [System.Runtime.Serialization.EnumMember(Value = @"Fail_ValuesNotFound")]
+        Fail_ValuesNotFound = 1,
 
-        _2 = 2,
+        [System.Runtime.Serialization.EnumMember(Value = @"Fail_ProofLocationNotFound")]
+        Fail_ProofLocationNotFound = 2,
 
-        _3 = 3,
+        [System.Runtime.Serialization.EnumMember(Value = @"Fail_ProofNotFound")]
+        Fail_ProofNotFound = 3,
 
-        _4 = 4,
+        [System.Runtime.Serialization.EnumMember(Value = @"Fail_RootHashMismatch")]
+        Fail_RootHashMismatch = 4,
 
-        _5 = 5,
+        [System.Runtime.Serialization.EnumMember(Value = @"Fail_SignatureMismatch")]
+        Fail_SignatureMismatch = 5,
 
-        _6 = 6,
+        [System.Runtime.Serialization.EnumMember(Value = @"Fail_InvalidPublicKey")]
+        Fail_InvalidPublicKey = 6,
 
-        _7 = 7,
+        [System.Runtime.Serialization.EnumMember(Value = @"Fail_ProofNotInChain")]
+        Fail_ProofNotInChain = 7,
 
-        _99 = 99,
+        [System.Runtime.Serialization.EnumMember(Value = @"State_ProofPending")]
+        State_ProofPending = 8,
 
     }
 


### PR DESCRIPTION
Added Validation Result and Validation Timestamp to the ProofLocation Entity, which can now be used to store the latest Validation Result of the given Proof. 
Added Get, Put REST Api's to update or query the ProofLocation by the URI. 
Added called Columns into Read and Create Model of ProofLocation
Added Migration for EF Core 
Added Update for EF Core CLI Tools